### PR TITLE
Remove ProximaNova-Regular hardcoding for no items

### DIFF
--- a/lib/react-native-multi-select.js
+++ b/lib/react-native-multi-select.js
@@ -173,7 +173,7 @@ export default class MultiSelect extends Component {
       />;
     } else {
       component = <View style={{flexDirection: 'row', alignItems: 'center'}}>
-        <Text style={{flex: 1, marginTop: 20, textAlign: 'center', fontFamily: 'ProximaNova-Regular', color: colorPack.danger}}>
+        <Text style={{flex: 1, marginTop: 20, textAlign: 'center', fontFamily: this.props.fontFamily ? this.props.fontFamily : '', color: colorPack.danger}}>
           No item to display.
         </Text>
       </View>;


### PR DESCRIPTION
Replace ProximaNova-Regular hardcoded fontFamily with this.props.fontFamily to prevent errors when ProximaNova-Regular is not available.