### PR TITLE
Do not try to display items not found

### DIFF
--- a/lib/react-native-multi-select.js
+++ b/lib/react-native-multi-select.js
@@ -126,6 +126,7 @@ export default class MultiSelect extends Component {
     } = this.props;
     return selectedItems.map(singleSelectedItem => {
       const item = this._findItem(singleSelectedItem);
+      if (item.name == null) return null;
       return (
         <View
           style={[


### PR DESCRIPTION
If you removed an item from `items`, but that item stil exist in your `selectedItems`-prop, then this module will fail because it tries to access this item.

This will fail because [the item is not found and an empty object is returned](https://github.com/toystars/react-native-multiple-select/blob/master/lib/react-native-multi-select.js#L95-L97), and then the [property `item.name.length` is accessed](https://github.com/toystars/react-native-multiple-select/blob/master/lib/react-native-multi-select.js#L134), but since `item.name` is `undefined` it will fail.

