### PR TITLE
Added prop to hide submit button

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The component takes 3 compulsory props - `items`, `uniqueKey` and `selectedItems
 | itemFontFamily | No   | (String) Font family for each non-selected item in multi-select drop-down |
 | itemTextColor | No   | (String) Text color for each non-selected item in multi-select drop-down |
 | searchInputStyle | No   | (Object) Style object for multi-select input element  |
+| hideSubmitButton | No | (Boolean) Defaults to false. Hide submit button from dropdown, and rather use arrow-button in search field"
 | submitButtonColor | No   | (String) Background color for submit button  |
 | submitButtonText | No   | (String) Text displayed on submit button  |
 

--- a/lib/react-native-multi-select.js
+++ b/lib/react-native-multi-select.js
@@ -41,6 +41,7 @@ export default class MultiSelect extends Component {
     searchInputStyle: PropTypes.object,
     selectText: PropTypes.string,
     altFontFamily: PropTypes.string,
+    hideSubmitButton: PropTypes.bool,
     submitButtonColor: PropTypes.string,
     submitButtonText: PropTypes.string,
     textColor: PropTypes.string,
@@ -68,6 +69,7 @@ export default class MultiSelect extends Component {
     textColor: colorPack.textPrimary,
     selectText: 'Select',
     altFontFamily: '',
+    hideSubmitButton: false,
     submitButtonColor: '#CCC',
     submitButtonText: 'Submit',
     fontSize: 14,
@@ -357,6 +359,7 @@ export default class MultiSelect extends Component {
       altFontFamily,
       searchInputPlaceholderText,
       searchInputStyle,
+      hideSubmitButton,
       submitButtonColor,
       submitButtonText,
       fontSize,
@@ -390,6 +393,14 @@ export default class MultiSelect extends Component {
                   underlineColorAndroid="transparent"
                   style={[searchInputStyle, { flex: 1 }]}
                 />
+                {hideSubmitButton &&
+                  <TouchableOpacity onPress={this._submitSelection}>
+                    <IconIonic
+                      name="md-arrow-dropdown"
+                      style={[styles.indicator, { paddingRight: 15 }]}
+                    />
+                  </TouchableOpacity>
+                }
               </View>
               <View
                 style={{
@@ -401,7 +412,7 @@ export default class MultiSelect extends Component {
                   {this._renderItems()}
                 </View>
                 {
-                  !single && 
+                  !single && !hideSubmitButton &&
                   <TouchableOpacity
                     onPress={() => this._submitSelection()}
                     style={[styles.button, { backgroundColor: submitButtonColor }]}
@@ -433,8 +444,8 @@ export default class MultiSelect extends Component {
                       >
                         {this._getSelectLabel()}
                       </Text>
-                      <Icon
-                        name="arrow-drop-down"
+                      <IconIonic
+                        name={hideSubmitButton ? "md-arrow-dropright" : "md-arrow-dropdown" }
                         style={styles.indicator}
                       />
                     </View>


### PR DESCRIPTION
Instead of showing a "Submit" button at the bottom, this props gives the ability to hide this button, and instead change the arrow in the right side of the search-field to an clickable expand/collapse button: 

![new](https://user-images.githubusercontent.com/2505178/31577585-baff9af4-b111-11e7-8f26-2f175060b100.png)

Here is how it looks with button shown:
![old](https://user-images.githubusercontent.com/2505178/31577590-c9845baa-b111-11e7-8869-ecddd26289cd.png)
