### PR TITLE
Flex on MultipleSelect parent view removed

### DIFF
--- a/lib/react-native-multi-select.js
+++ b/lib/react-native-multi-select.js
@@ -393,7 +393,6 @@ export default class MultiSelect extends Component {
     return (
       <View
         style={{
-          flex: 1,
           flexDirection: 'column',
           marginBottom: 10,
         }}


### PR DESCRIPTION

At present the Main View inside the lib is taking `flex: 1` 
https://github.com/toystars/react-native-multiple-select/blob/010aaa609f49bdae8748b6beaf8ce95ea46c2a58/lib/react-native-multi-select.js#L396

Below is snapshot of present state of UI.
![preset status](http://i.imgur.com/jnDABlJ.gif)

I would like my component (yellow part) in above gif to be right below the selector. I think it is safe enough to remove the line to make it less greedy in terms of the height it occupies. Below is final result of this pull request.
![solution](http://i.imgur.com/06Xa7Wp.gif) 


The code I am using to test is as follow
```jsx
 <View style={{flex: 1}}>
  <MultiSelect
    fixedHeight={false}
    hideTags
    items={this.items}
    uniqueKey="id"
    ref={(component) => { this.multiSelect = component }}
    onSelectedItemsChange={this.onSelectedItemsChange}
    selectedItems={selectedItems}
    selectText="Pick Items"
    searchInputPlaceholderText="Search Items..."
    altFontFamily="ProximaNova-Light"
    tagRemoveIconColor="#CCC"
    tagBorderColor="#CCC"
    tagTextColor="#CCC"
    selectedItemTextColor="#CCC"
    selectedItemIconColor="#CCC"
    itemTextColor="#000"
    searchInputStyle={{ color: '#CCC' }}
    submitButtonColor="#CCC"
    submitButtonText="Submit"
  />
  <View>
    {this.multiSelect && this.multiSelect.getSelectedItemsExt(selectedItems)}
  </View>
  
  <View style={{backgroundColor: 'gold'}}>
    <Text> Hello World</Text>
    <Text> Hello World</Text>
    <Text> Hello World</Text>
    <Text> Hello World</Text>
  </View>
</View>
```