### PR TITLE
Condition check added to avoid empty object spread

### DIFF
--- a/lib/react-native-multi-select.js
+++ b/lib/react-native-multi-select.js
@@ -283,7 +283,9 @@ export default class MultiSelect extends Component {
           singleItem => item[uniqueKey] === singleItem,
         );
       } else {
-        newItems = [...selectedItems, item[uniqueKey]];
+        if (selectedItems === undefined || selectedItems.length == 0)
+          newItems = [item[uniqueKey]];
+        else newItems = [...selectedItems, item[uniqueKey]];
       }
       // broadcast new selected items state to parent component
       onSelectedItemsChange(newItems);


### PR DESCRIPTION
After upgrading react native to 0.56.0, app is crashing in release mode on item select, added this condition and its not crashing any more.

[issue 76](https://github.com/toystars/react-native-multiple-select/issues/76)