### PR TITLE
Update react-native-multi-select.js

### DIFF
--- a/lib/react-native-multi-select.js
+++ b/lib/react-native-multi-select.js
@@ -480,6 +480,7 @@ export default class MultiSelect extends Component {
     if (renderItems.length) {
       itemList = (
         <FlatList
+          nestedScrollEnabled={true}
           data={renderItems}
           extraData={selectedItems}
           keyExtractor={item => item[uniqueKey]}


### PR DESCRIPTION
added "nestedScrollEnabled={true}" attribute to FlatList inside "_renderItems" method. This solves the scroll problem of the list if the component is rendered inside a ScrollView. Also note if the multiselect is placed inside a ScrollView, this parent ScrollView should also enable nested scroll using the same attribute.