### PR TITLE
Solving FlatList keyExtractor Error

### DIFF
--- a/lib/react-native-multi-select.js
+++ b/lib/react-native-multi-select.js
@@ -503,7 +503,7 @@ export default class MultiSelect extends Component {
         <FlatList
           data={renderItems}
           extraData={selectedItems}
-          keyExtractor={item => item[uniqueKey]}
+          keyExtractor={(item, index) => index.toString()}
           listKey={item => item[uniqueKey]}
           renderItem={rowData => this._getRow(rowData.item)}
           {...flatListProps}


### PR DESCRIPTION
This changement solve 
Error:
Warning: Failed child context type: Invalid child context `virtualizedCell.cellKey` of type `number` supplied to `CellRenderer`, expected `string`.