### PR TITLE
Added prop for no items text

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,7 @@ export interface MultiSelectProps {
     textInputProps?: TextInputProps;
     flatListProps?: FlatListProps<any>;
     filterMethod?: string;
+    noItemsText?: string;
 }
 
 export default class MultiSelect extends React.Component<MultiSelectProps> {

--- a/lib/react-native-multi-select.js
+++ b/lib/react-native-multi-select.js
@@ -83,7 +83,8 @@ export default class MultiSelect extends Component {
     filterMethod: PropTypes.string,
     onClearSelector: PropTypes.func,
     onToggleList: PropTypes.func,
-    removeSelected: PropTypes.bool
+    removeSelected: PropTypes.bool,
+    noItemsText: PropTypes.string
   };
 
   static defaultProps = {
@@ -119,7 +120,8 @@ export default class MultiSelect extends Component {
     onAddItem: () => {},
     onClearSelector: () => {},
     onToggleList: () => {},
-    removeSelected: false
+    removeSelected: false,
+    noItemsText: 'No items to display.'
   };
 
   constructor(props) {
@@ -482,7 +484,8 @@ export default class MultiSelect extends Component {
       selectedItems,
       flatListProps,
       styleListContainer,
-      removeSelected
+      removeSelected,
+      noItemsText
     } = this.props;
     const { searchTerm } = this.state;
     let component = null;
@@ -526,7 +529,7 @@ export default class MultiSelect extends Component {
               fontFamily ? { fontFamily } : {}
             ]}
           >
-            No item to display.
+            {noItemsText}
           </Text>
         </View>
       );


### PR DESCRIPTION
### What's Changed
Added prop `noItemsText` for custom text displayed in the case no items are provided or when no items match the search input field text. DefaultProp =  `No items to display. `

![Screen Shot 2021-08-23 at 1 01 35 PM](https://user-images.githubusercontent.com/46830250/130487497-39da5982-ca9f-48eb-855d-4ee508135d4e.png)