### PR TITLE
[*] Fixed: ViewPropTypes will be removed from React Native. Migrate t…

### DIFF
--- a/lib/react-native-multi-select.js
+++ b/lib/react-native-multi-select.js
@@ -7,8 +7,8 @@ import {
   TouchableOpacity,
   FlatList,
   UIManager,
-  ViewPropTypes
 } from 'react-native';
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
 import PropTypes from 'prop-types';
 import reject from 'lodash/reject';
 import find from 'lodash/find';


### PR DESCRIPTION
ViewPropTypes exported from 'deprecated-react-native-prop-types'